### PR TITLE
 Isolate street furnitures to a separate layer 

### DIFF
--- a/style.json
+++ b/style.json
@@ -3787,6 +3787,101 @@
       }
     },
     {
+      "id": "poi-level-street-furniture",
+      "type": "symbol",
+      "source": "poi",
+      "source-layer": "poi",
+      "minzoom": 17,
+      "filter": [
+          "all",
+          [
+              "==",
+              "$type",
+              "Point"
+          ],
+          [
+              "any",
+              [
+                  "==",
+                  "subclass",
+                  "bollard"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "border_control"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "cycle_barrier"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "gate"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "lift_gate"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "post_box"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "sally_port"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "stile"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "telephone"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "toll_booth"
+              ],
+              [
+                  "==",
+                  "subclass",
+                  "waste_basket"
+              ]
+          ]
+      ],
+      "layout": {
+        "text-size": 11,
+        "icon-image": "{subclass}-11",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-padding": 2,
+        "text-offset": [
+          0,
+          1.4
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-optional": true,
+        "text-max-width": 9
+      },
+      "paint": {
+        "text-halo-blur": 0.5,
+        "text-color": "#000",
+        "text-halo-width": 0.8,
+        "text-halo-color": "#ffffff"
+      }
+    },
+    {
       "id": "poi-level-3",
       "type": "symbol",
       "source": "poi",
@@ -3803,7 +3898,65 @@
           ">=",
           "rank",
           25
-        ]
+      ],
+      [
+          "all",
+          [
+              "!=",
+              "subclass",
+              "bollard"
+          ],
+          [
+              "!=",
+              "subclass",
+              "border_control"
+          ],
+          [
+              "!=",
+              "subclass",
+              "cycle_barrier"
+          ],
+          [
+              "!=",
+              "subclass",
+              "gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "lift_gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "post_box"
+          ],
+          [
+              "!=",
+              "subclass",
+              "sally_port"
+          ],
+          [
+              "!=",
+              "subclass",
+              "stile"
+          ],
+          [
+              "!=",
+              "subclass",
+              "telephone"
+          ],
+          [
+              "!=",
+              "subclass",
+              "toll_booth"
+          ],
+          [
+              "!=",
+              "subclass",
+              "waste_basket"
+          ]
+      ]
       ],
       "layout": {
         "text-size": 11,
@@ -3853,7 +4006,65 @@
             "rank",
             15
           ]
-        ]
+      ],
+      [
+          "all",
+          [
+              "!=",
+              "subclass",
+              "bollard"
+          ],
+          [
+              "!=",
+              "subclass",
+              "border_control"
+          ],
+          [
+              "!=",
+              "subclass",
+              "cycle_barrier"
+          ],
+          [
+              "!=",
+              "subclass",
+              "gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "lift_gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "post_box"
+          ],
+          [
+              "!=",
+              "subclass",
+              "sally_port"
+          ],
+          [
+              "!=",
+              "subclass",
+              "stile"
+          ],
+          [
+              "!=",
+              "subclass",
+              "telephone"
+          ],
+          [
+              "!=",
+              "subclass",
+              "toll_booth"
+          ],
+          [
+              "!=",
+              "subclass",
+              "waste_basket"
+          ]
+      ]
       ],
       "layout": {
         "text-padding": 2,
@@ -3898,7 +4109,65 @@
             "rank",
             14
           ]
-        ]
+      ],
+      [
+          "all",
+          [
+              "!=",
+              "subclass",
+              "bollard"
+          ],
+          [
+              "!=",
+              "subclass",
+              "border_control"
+          ],
+          [
+              "!=",
+              "subclass",
+              "cycle_barrier"
+          ],
+          [
+              "!=",
+              "subclass",
+              "gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "lift_gate"
+          ],
+          [
+              "!=",
+              "subclass",
+              "post_box"
+          ],
+          [
+              "!=",
+              "subclass",
+              "sally_port"
+          ],
+          [
+              "!=",
+              "subclass",
+              "stile"
+          ],
+          [
+              "!=",
+              "subclass",
+              "telephone"
+          ],
+          [
+              "!=",
+              "subclass",
+              "toll_booth"
+          ],
+          [
+              "!=",
+              "subclass",
+              "waste_basket"
+          ]
+      ]
       ],
       "layout": {
         "text-size": 10,

--- a/style.json
+++ b/style.json
@@ -3793,70 +3793,70 @@
       "source-layer": "poi",
       "minzoom": 17,
       "filter": [
-          "all",
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "any",
           [
-              "==",
-              "$type",
-              "Point"
+            "==",
+            "subclass",
+            "bollard"
           ],
           [
-              "any",
-              [
-                  "==",
-                  "subclass",
-                  "bollard"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "border_control"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "cycle_barrier"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "gate"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "lift_gate"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "post_box"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "sally_port"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "stile"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "telephone"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "toll_booth"
-              ],
-              [
-                  "==",
-                  "subclass",
-                  "waste_basket"
-              ]
+            "==",
+            "subclass",
+            "border_control"
+          ],
+          [
+            "==",
+            "subclass",
+            "cycle_barrier"
+          ],
+          [
+            "==",
+            "subclass",
+            "gate"
+          ],
+          [
+            "==",
+            "subclass",
+            "lift_gate"
+          ],
+          [
+            "==",
+            "subclass",
+            "post_box"
+          ],
+          [
+            "==",
+            "subclass",
+            "sally_port"
+          ],
+          [
+            "==",
+            "subclass",
+            "stile"
+          ],
+          [
+            "==",
+            "subclass",
+            "telephone"
+          ],
+          [
+            "==",
+            "subclass",
+            "toll_booth"
+          ],
+          [
+            "==",
+            "subclass",
+            "waste_basket"
           ]
+        ]
       ],
       "layout": {
         "text-size": 11,
@@ -3870,7 +3870,6 @@
           1.4
         ],
         "text-anchor": "top",
-        "text-field": "{name}",
         "text-optional": true,
         "text-max-width": 9
       },
@@ -3898,65 +3897,65 @@
           ">=",
           "rank",
           25
-      ],
-      [
+        ],
+        [
           "all",
           [
-              "!=",
-              "subclass",
-              "bollard"
+            "!=",
+            "subclass",
+            "bollard"
           ],
           [
-              "!=",
-              "subclass",
-              "border_control"
+            "!=",
+            "subclass",
+            "border_control"
           ],
           [
-              "!=",
-              "subclass",
-              "cycle_barrier"
+            "!=",
+            "subclass",
+            "cycle_barrier"
           ],
           [
-              "!=",
-              "subclass",
-              "gate"
+            "!=",
+            "subclass",
+            "gate"
           ],
           [
-              "!=",
-              "subclass",
-              "lift_gate"
+            "!=",
+            "subclass",
+            "lift_gate"
           ],
           [
-              "!=",
-              "subclass",
-              "post_box"
+            "!=",
+            "subclass",
+            "post_box"
           ],
           [
-              "!=",
-              "subclass",
-              "sally_port"
+            "!=",
+            "subclass",
+            "sally_port"
           ],
           [
-              "!=",
-              "subclass",
-              "stile"
+            "!=",
+            "subclass",
+            "stile"
           ],
           [
-              "!=",
-              "subclass",
-              "telephone"
+            "!=",
+            "subclass",
+            "telephone"
           ],
           [
-              "!=",
-              "subclass",
-              "toll_booth"
+            "!=",
+            "subclass",
+            "toll_booth"
           ],
           [
-              "!=",
-              "subclass",
-              "waste_basket"
+            "!=",
+            "subclass",
+            "waste_basket"
           ]
-      ]
+        ]
       ],
       "layout": {
         "text-size": 11,
@@ -4006,65 +4005,65 @@
             "rank",
             15
           ]
-      ],
-      [
+        ],
+        [
           "all",
           [
-              "!=",
-              "subclass",
-              "bollard"
+            "!=",
+            "subclass",
+            "bollard"
           ],
           [
-              "!=",
-              "subclass",
-              "border_control"
+            "!=",
+            "subclass",
+            "border_control"
           ],
           [
-              "!=",
-              "subclass",
-              "cycle_barrier"
+            "!=",
+            "subclass",
+            "cycle_barrier"
           ],
           [
-              "!=",
-              "subclass",
-              "gate"
+            "!=",
+            "subclass",
+            "gate"
           ],
           [
-              "!=",
-              "subclass",
-              "lift_gate"
+            "!=",
+            "subclass",
+            "lift_gate"
           ],
           [
-              "!=",
-              "subclass",
-              "post_box"
+            "!=",
+            "subclass",
+            "post_box"
           ],
           [
-              "!=",
-              "subclass",
-              "sally_port"
+            "!=",
+            "subclass",
+            "sally_port"
           ],
           [
-              "!=",
-              "subclass",
-              "stile"
+            "!=",
+            "subclass",
+            "stile"
           ],
           [
-              "!=",
-              "subclass",
-              "telephone"
+            "!=",
+            "subclass",
+            "telephone"
           ],
           [
-              "!=",
-              "subclass",
-              "toll_booth"
+            "!=",
+            "subclass",
+            "toll_booth"
           ],
           [
-              "!=",
-              "subclass",
-              "waste_basket"
+            "!=",
+            "subclass",
+            "waste_basket"
           ]
-      ]
+        ]
       ],
       "layout": {
         "text-padding": 2,
@@ -4109,65 +4108,65 @@
             "rank",
             14
           ]
-      ],
-      [
+        ],
+        [
           "all",
           [
-              "!=",
-              "subclass",
-              "bollard"
+            "!=",
+            "subclass",
+            "bollard"
           ],
           [
-              "!=",
-              "subclass",
-              "border_control"
+            "!=",
+            "subclass",
+            "border_control"
           ],
           [
-              "!=",
-              "subclass",
-              "cycle_barrier"
+            "!=",
+            "subclass",
+            "cycle_barrier"
           ],
           [
-              "!=",
-              "subclass",
-              "gate"
+            "!=",
+            "subclass",
+            "gate"
           ],
           [
-              "!=",
-              "subclass",
-              "lift_gate"
+            "!=",
+            "subclass",
+            "lift_gate"
           ],
           [
-              "!=",
-              "subclass",
-              "post_box"
+            "!=",
+            "subclass",
+            "post_box"
           ],
           [
-              "!=",
-              "subclass",
-              "sally_port"
+            "!=",
+            "subclass",
+            "sally_port"
           ],
           [
-              "!=",
-              "subclass",
-              "stile"
+            "!=",
+            "subclass",
+            "stile"
           ],
           [
-              "!=",
-              "subclass",
-              "telephone"
+            "!=",
+            "subclass",
+            "telephone"
           ],
           [
-              "!=",
-              "subclass",
-              "toll_booth"
+            "!=",
+            "subclass",
+            "toll_booth"
           ],
           [
-              "!=",
-              "subclass",
-              "waste_basket"
+            "!=",
+            "subclass",
+            "waste_basket"
           ]
-      ]
+        ]
       ],
       "layout": {
         "text-size": 10,


### PR DESCRIPTION
This is patch to handle the street furnitures in a better way:
- display an icon but never display their name (nobody care about the name of a lift gate :unamused: )
- display from zoom 17 without taking the rank into account

The separate layer also allow to remove the interactivity in our frontend for these items that nobody would ever want to click.

This is quite a poor way to handle this, but I think this is the best we can do without any changes in the tiles.