### PR TITLE
add a few missing icons for sport facilities

### DIFF
--- a/icons.yml
+++ b/icons.yml
@@ -88,7 +88,19 @@ mappings:
   - subclass: golf_course
     iconName: golf-11
     color: '#00CB4F'
+  - subclass: golf
+    iconName: golf-11
+    color: '#00CB4F'
+  - subclass: miniature_golf
+    iconName: golf-11
+    color: '#00CB4F'
   - subclass: swimming_pool
+    iconName: swimming-11
+    color: '#8A9CF6'
+  - subclass: swimming
+    iconName: swimming-11
+    color: '#8A9CF6'
+  - subclass: swimming_area
     iconName: swimming-11
     color: '#8A9CF6'
   - subclass: bicycle_rental


### PR DESCRIPTION
Golf and swimming facilities have their custom class in OpenMapTiles (don't ask me why only these one :woman_shrugging:)

These PR add custom icons for them.

You can test theses at
* debug.html#17.76/45.61943/5.1291 (a swimming area)
* debug.html#16.43/48.837211/2.443086  (a mini-golf)