### PR TITLE
Improve tunnels

### DIFF
--- a/style.json
+++ b/style.json
@@ -809,6 +809,10 @@
       },
       "paint": {
         "line-color": "#cfcdca",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
         "line-opacity": {
           "stops": [
             [
@@ -873,6 +877,10 @@
       },
       "paint": {
         "line-color": "#e9ac77",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
@@ -883,7 +891,7 @@
             ],
             [
               20,
-              17
+              15
             ]
           ]
         }
@@ -895,7 +903,7 @@
       "metadata": {
         "mapbox:group": "1444849354174.1904",
         "taxonomy:group": "tunnels",
-        "taxonomy:casing": "tunnel-secondary-primary"
+        "taxonomy:casing": "tunnel-trunk-primary"
       },
       "source": "basemap",
       "source-layer": "transportation",
@@ -918,6 +926,10 @@
       },
       "paint": {
         "line-color": "#e9ac77",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
         "line-width": {
           "base": 1.2,
           "stops": [


### PR DESCRIPTION
This commit adds better casing for:
* minor tunnel
* secondary/tertiary tunnel
* trunk/primary tunnel

Minor example:
![minor-near-strasbourg-magenta](https://user-images.githubusercontent.com/5153882/46936931-45209080-d060-11e8-8909-08e7c7b2f3e0.png)

Secondary/tertiary example:
![secondary-tertiary-tuileries](https://user-images.githubusercontent.com/5153882/46936936-49e54480-d060-11e8-89a0-c3b1151c6005.png)

Trunk/primary example:
![trunk-primary-at-porte-maillot](https://user-images.githubusercontent.com/5153882/46936947-4ce03500-d060-11e8-965a-6f8aca94adeb.png)
