### PR TITLE
Roads too visible

### DIFF
--- a/style.json
+++ b/style.json
@@ -1360,90 +1360,6 @@
       }
     },
     {
-      "id": "aeroway-taxiway-casing",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436",
-          "taxonomy:group": "bridges",
-          "taxonomy:casing": "aeroway-taxiway"
-      },
-      "source": "basemap",
-      "source-layer": "aeroway",
-      "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "taxiway"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(153, 153, 153, 1)",
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              17,
-              12
-            ]
-          ]
-        },
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "aeroway-runway-casing",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436",
-          "taxonomy:group": "bridges",
-          "taxonomy:casing": "aeroway-runway"
-      },
-      "source": "basemap",
-      "source-layer": "aeroway",
-      "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "runway"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(153, 153, 153, 1)",
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              5
-            ],
-            [
-              17,
-              55
-            ]
-          ]
-        },
-        "line-opacity": 1
-      }
-    },
-    {
       "id": "aeroway-area",
       "type": "fill",
       "metadata": {
@@ -1511,7 +1427,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -1569,7 +1485,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -1800,16 +1716,16 @@
               0.5
             ],
             [
-              13,
-              1
+              13.5,
+              2
             ],
             [
               14,
-              1
+              3
             ],
             [
               20,
-              10
+              15.5
             ]
           ]
         }
@@ -2282,7 +2198,7 @@
             ],
             [
               14,
-              2.5
+              1
             ],
             [
               20,
@@ -2984,7 +2900,7 @@
             ],
             [
               20,
-              28
+              17
             ]
           ]
         }
@@ -3024,7 +2940,7 @@
           "stops": [
             [
               5,
-              0.4
+              0
             ],
             [
               6,
@@ -3036,7 +2952,7 @@
             ],
             [
               20,
-              26
+              22
             ]
           ]
         }
@@ -3331,12 +3247,12 @@
               0
             ],
             [
-              7,
+              8,
               0.5
             ],
             [
               20,
-              20
+              13
             ]
           ]
         }


### PR DESCRIPTION
This PR improves
* road style at zoom 13+ (for parkings and path in parks) & highway-minor casing for zoom 14+
![parkings](https://user-images.githubusercontent.com/5153882/46999463-081ed180-d126-11e8-993a-3e49e4b49927.png)
* aeroways (remove casing which accentuates lines too much and add reduce opacity)
![aeroways](https://user-images.githubusercontent.com/5153882/46999419-ee7d8a00-d125-11e8-9c48-146ab57ef308.png)

This PR removes highway bridges styles:
* secondary-tertiary (smaller dark orange)
![secondary-tertiary-bridge](https://user-images.githubusercontent.com/5153882/46999483-140a9380-d126-11e8-9ad2-c971afe8227f.png)
* trunk-primary (smaller dark orange)
![trunk-primary-bridge](https://user-images.githubusercontent.com/5153882/46999489-1836b100-d126-11e8-970f-9d28c2498384.png)

To go further, if you want to remove [way/183600056](https://www.openstreetmap.org/way/183600056) (bridge polygons) You should remove it from your mapping.yaml `man_made: bridge`