### PR TITLE
Update grass and building layers

### DIFF
--- a/style.json
+++ b/style.json
@@ -762,67 +762,23 @@
       },
       "source": "basemap",
       "source-layer": "building",
-      "paint": {
-        "fill-color": {
-          "base": 1,
-          "stops": [
-            [
-              15.5,
-              "hsla(0, 0%, 95%, 0)"
-            ],
-            [
-              16,
-              "hsla(0, 0%, 84%, 0)"
-            ]
-          ]
-        },
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "building-top",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849364238.8171",
-        "taxonomy:group": "building"
-      },
-      "source": "basemap",
-      "source-layer": "building",
+      "minzoom": 15,
       "layout": {
         "visibility": "visible"
       },
       "paint": {
-        "fill-translate": {
-          "base": 1,
-          "stops": [
-            [
-              14,
-              [
-                0,
-                0
-              ]
-            ],
-            [
-              16,
-              [
-                -2,
-                -2
-              ]
-            ]
-          ]
-        },
-        "fill-outline-color": "#dfdbd7",
+        "fill-outline-color": "#d5d0cb",
         "fill-color": "hsl(0, 0%, 93%)",
         "fill-opacity": {
           "base": 1,
           "stops": [
             [
-              15.9,
+              15.5,
               0
             ],
             [
               16,
-              0.8
+              0.9
             ]
           ]
         }

--- a/style.json
+++ b/style.json
@@ -372,6 +372,42 @@
       }
     },
     {
+      "id": "landcover-garden",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071",
+        "taxonomy:group": "landuse"
+      },
+      "source": "basemap",
+      "source-layer": "landcover",
+      "filter": [
+        "all",
+        ["==", "class", "grass"],
+        ["in", "subclass", "park", "garden"]
+      ],
+      "paint": {
+        "fill-color": "#c0eab8"
+      }
+    },
+    {
+      "id": "landcover-grass",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071",
+        "taxonomy:group": "landuse"
+      },
+      "source": "basemap",
+      "source-layer": "landcover",
+      "filter": [
+        "all",
+        ["==", "class", "grass"],
+        ["!in", "subclass", "park", "garden"]
+      ],
+      "paint": {
+        "fill-color": "#e0f2d3"
+      }
+    },
+    {
       "id": "landcover-wood",
       "type": "fill",
       "metadata": {
@@ -386,8 +422,8 @@
         "wood"
       ],
       "paint": {
-        "fill-color": "#6a4",
-        "fill-opacity": 0.1,
+        "fill-color": "#cae4be",
+        "fill-opacity": 1,
         "fill-outline-color": "hsla(0, 0%, 0%, 0.03)",
         "fill-antialias": {
           "base": 1,
@@ -402,25 +438,6 @@
             ]
           ]
         }
-      }
-    },
-    {
-      "id": "landcover-grass",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071",
-        "taxonomy:group": "landuse"
-      },
-      "source": "basemap",
-      "source-layer": "landcover",
-      "filter": [
-        "==",
-        "class",
-        "grass"
-      ],
-      "paint": {
-        "fill-color": "#B7EBBF",
-        "fill-opacity": 1
       }
     },
     {
@@ -5287,10 +5304,6 @@
       }
     }
   ],
-  "created": "2017-12-19T09:39:33.365Z",
   "id": "cjbdftwmm936t2rquyt8ycvor",
-  "modified": "2017-12-19T10:13:03.220Z",
-  "owner": "clementaupiais",
-  "visibility": "private",
-  "draft": false
+  "visibility": "private"
 }

--- a/style.json
+++ b/style.json
@@ -2151,7 +2151,7 @@
         ]
       ],
       "paint": {
-        "line-color": "hsla(0, 0%, 0%, 0.05)",
+        "line-color": "hsla(0, 0%, 0%, 0.07)",
         "line-dasharray": [
           1.5,
           0.75


### PR DESCRIPTION
This is an attempt to fix #60 (thanks @sylvain-m)

* Replace "grass" and "wood" layers with 3 layers:
  * "landcover-garden"
  * "landcover-grass"
  * "landcover-wood"

Note that the order of these layers is important to preserve details in park and garden (for examples wood areas inside gardens)

* Improve building contrast
   * Update building outline:  `#dfdbd7` :arrow_right: `#d5d0cb` 
   * Remove unnecessary layer:  we had 2 layers "building" and "building-top" (used by the original style to create a shadow effect) but only one has non-zero opacity
  * The maximum building opacity is now 0.9 (instead of 0.8). With a value below 100% some areas that intersects buildings keep (very lightly) visible. See this garden on top of a reservoir: 
https://www.qwant.com/maps/#map=17.79/48.8699074/2.2900530


