### PR TITLE
add back names for subway_entrance

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -73,6 +73,10 @@ languageFallbacks:
     lang:
       *lang_locale
   -
+    id: poi-level-street-furniture
+    lang:
+      *lang_locale
+  -
     id: poi-level-3
     lang:
       *lang_locale

--- a/style.json
+++ b/style.json
@@ -4088,7 +4088,7 @@
         ]
       ],
       "layout": {
-        "text-size": 11,
+        "text-size": 10,
         "icon-image": "{subclass}-11",
         "text-font": [
           "Noto Sans Regular"
@@ -4099,6 +4099,7 @@
           1.4
         ],
         "text-anchor": "top",
+        "text-field": "{name}",
         "text-optional": true,
         "text-max-width": 9
       },


### PR DESCRIPTION
Most street furniture don't have names so we did chose to not display them.

But it is a very cool feature to have the names of the subway entrances (even if we don't want to make then clickable) so I add the `name` display for the street furniture.