### PR TITLE
QMAPS-1058: make marker2 the default icon

### DIFF
--- a/icons.yml
+++ b/icons.yml
@@ -1,4 +1,4 @@
-defaultIcon: marker-11
+defaultIcon: marker2-11
 defaultColor: '#5C6F84'
 defaultAdministrativeIcon: town-11
 defaultAdministrativeColor: '#5c6f84'


### PR DESCRIPTION
Screenshot: POI that has no class/subclass and using marker-2 by default

![image](https://user-images.githubusercontent.com/1225909/67207735-715db280-f414-11e9-9353-b7a8b8d5e361.png)

