### PR TITLE
Update style with changes from OpenMapTiles 3.10

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -121,6 +121,10 @@ languageFallbacks:
     lang:
       *lang_locale
   -
+    id: park-label
+    lang:
+      *lang_locale
+  -
     id: place-other
     lang: "{name}"
   -

--- a/style.json
+++ b/style.json
@@ -3649,7 +3649,6 @@
       "source": "basemap",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": [
         "==",
         "class",
@@ -3682,7 +3681,6 @@
       "source": "basemap",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": [
         "==",
         "class",

--- a/style.json
+++ b/style.json
@@ -539,6 +539,51 @@
       }
     },
     {
+      "id": "waterway_tunnel",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "river",
+          "stream",
+          "canal"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          4
+        ]
+      },
+      "minzoom": 14
+    },
+    {
       "id": "waterway-other",
       "type": "line",
       "metadata": {
@@ -584,10 +629,18 @@
       "source": "basemap",
       "source-layer": "waterway",
       "filter": [
-        "in",
-        "class",
-        "canal",
-        "stream"
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
       ],
       "layout": {
         "line-cap": "round"
@@ -619,9 +672,17 @@
       "source": "basemap",
       "source-layer": "waterway",
       "filter": [
-        "==",
-        "class",
-        "river"
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
       ],
       "layout": {
         "line-cap": "round"

--- a/style.json
+++ b/style.json
@@ -5288,7 +5288,7 @@
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
       },
-      "minzoom": 0
+      "minzoom": 11
     },
     {
       "id": "place-other",

--- a/style.json
+++ b/style.json
@@ -1712,6 +1712,73 @@
       }
     },
     {
+      "id": "road_area_pier",
+      "type": "fill",
+      "metadata": {},
+      "source": "basemap",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#f8f4f0",
+        "fill-antialias": true
+      }
+    },
+    {
+      "id": "road_pier",
+      "type": "line",
+      "metadata": {},
+      "source": "basemap",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              17,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
       "id": "highway-area",
       "type": "fill",
       "metadata": {
@@ -1721,9 +1788,17 @@
       "source": "basemap",
       "source-layer": "transportation",
       "filter": [
-        "==",
-        "$type",
-        "Polygon"
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!in",
+          "class",
+          "pier"
+        ]
       ],
       "layout": {
         "visibility": "visible"

--- a/style.json
+++ b/style.json
@@ -5276,7 +5276,7 @@
         "text-font": [
           "Noto Sans Bold"
         ],
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": "{name}",
         "text-transform": "none",
         "text-max-width": 9,
         "visibility": "visible",

--- a/style.json
+++ b/style.json
@@ -815,6 +815,30 @@
       }
     },
     {
+      "id": "landcover-sand",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "basemap",
+      "source-layer": "landcover",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "sand"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(245, 238, 188, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "building",
       "type": "fill",
       "metadata": {

--- a/style.json
+++ b/style.json
@@ -556,7 +556,7 @@
         ]
       ],
       "type": "line",
-      "source": "openmaptiles",
+      "source": "basemap",
       "source-layer": "waterway",
       "layout": {
         "line-cap": "round"
@@ -5026,6 +5026,54 @@
         "text-halo-width": 1,
         "text-halo-color": "#ffffff"
       }
+    },
+    {
+      "id": "park-label",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "basemap",
+      "source-layer": "park_label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "rank",
+          1
+        ]
+      ],
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              15,
+              14
+            ]
+          ]
+        },
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-transform": "none",
+        "text-max-width": 9,
+        "visibility": "visible",
+        "text-allow-overlap": false,
+        "text-ignore-placement": false
+      },
+      "paint": {
+        "text-color": "rgba(38, 92, 46, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      },
+      "minzoom": 0
     },
     {
       "id": "place-other",

--- a/style.json
+++ b/style.json
@@ -157,11 +157,7 @@
       },
       "source": "basemap",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "residential"
-      ],
+      "filter": ["all", ["in", "class", "residential", "suburb", "neighbourhood"]],
       "paint": {
         "fill-color": {
           "base": 1,
@@ -592,12 +588,9 @@
       },
       "source": "basemap",
       "source-layer": "waterway",
-      "filter": [
-        "!in",
-        "class",
-        "canal",
-        "river",
-        "stream"
+      "filter": ["all",
+        ["!in", "class", "canal", "river", "stream"],
+        ["!=", "intermittent", 1]
       ],
       "layout": {
         "line-cap": "round"
@@ -617,6 +610,34 @@
             ]
           ]
         }
+      }
+    },
+    {
+      "id": "waterway-other-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "basemap",
+      "source-layer": "waterway",
+      "filter": ["all",
+        ["!in", "class", "canal", "river", "stream"],
+        ["==", "intermittent", 1]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [13, 0.5],
+            [20, 2]
+          ]
+        },
+        "line-dasharray": [4, 3]
       }
     },
     {
@@ -640,7 +661,52 @@
           "!=",
           "brunnel",
           "tunnel"
-        ]
+        ],
+        ["!=", "intermittent", 1]
+      ],
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-stream-canal-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77",
+        "taxonomy:group": "waterway"
+      },
+      "source": "basemap",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        ["==", "intermittent", 1]
       ],
       "layout": {
         "line-cap": "round"
@@ -682,7 +748,8 @@
           "!=",
           "brunnel",
           "tunnel"
-        ]
+        ],
+        ["!=", "intermittent", 1]
       ],
       "layout": {
         "line-cap": "round"
@@ -702,6 +769,50 @@
             ]
           ]
         }
+      }
+    },
+    {
+      "id": "waterway-river-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77",
+        "taxonomy:group": "waterway"
+      },
+      "source": "basemap",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        ["==", "intermittent", 1]
+      ],
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        },
+        "line-dasharray": [3, 2.5]
       }
     },
     {
@@ -754,6 +865,7 @@
       },
       "source": "basemap",
       "source-layer": "water",
+      "filter": ["all", ["!=", "intermittent", 1]],
       "layout": {
         "visibility": "visible"
       },
@@ -762,22 +874,21 @@
       }
     },
     {
-      "id": "water-pattern",
+      "id": "water-intermittent",
       "type": "fill",
       "metadata": {
-        "mapbox:group": "1444849382550.77"
+        "mapbox:group": "1444849382550.77",
+        "taxonomy:group": "landuse"
       },
       "source": "basemap",
       "source-layer": "water",
+      "filter": ["all", ["==", "intermittent", 1]],
       "layout": {
         "visibility": "visible"
       },
       "paint": {
-        "fill-translate": [
-          0,
-          2.5
-        ],
-        "fill-color": "#BBE0FC"
+        "fill-color": "#BBE0FC",
+        "fill-opacity": 0.7
       }
     },
     {

--- a/style.json
+++ b/style.json
@@ -1876,7 +1876,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -1928,7 +1928,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -1999,7 +1999,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -2070,7 +2070,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },

--- a/style.json
+++ b/style.json
@@ -5034,13 +5034,18 @@
         "mapbox:group": "1444849242106.713"
       },
       "source": "basemap",
-      "source-layer": "park_label",
+      "source-layer": "park",
       "filter": [
         "all",
         [
           "==",
           "rank",
           1
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
         ]
       ],
       "layout": {


### PR DESCRIPTION
Following https://github.com/QwantResearch/openmaptiles/pull/21

Most of theses changes have been cherry-picked and adapted from https://github.com/openmaptiles/osm-bright-gl-style

The most visibles changes are about beaches and protected areas:

![Peek 19-12-2019 17-45](https://user-images.githubusercontent.com/4726554/71192410-80cc7100-2288-11ea-8bec-c3242aff18f5.gif)
