### PR TITLE
Fix label color and position for airports

### DIFF
--- a/style.json
+++ b/style.json
@@ -4952,7 +4952,7 @@
         "text-field": "{name}",
         "text-offset": [
           0,
-          0.6
+          1
         ],
         "text-size": 12,
         "text-max-width": 9,
@@ -4962,7 +4962,7 @@
       },
       "paint": {
         "text-halo-blur": 0.5,
-        "text-color": "#8665E7",
+        "text-color": "#123295",
         "text-halo-width": 1,
         "text-halo-color": "#ffffff"
       }


### PR DESCRIPTION
Color of airport labels was not updated in #77 where icons changed.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/67488187-ab76c080-f66f-11e9-8c6c-8a494b72abf5.png) |![image](https://user-images.githubusercontent.com/4726554/67491367-1f679780-f675-11e9-9a9c-6946330494fa.png)|

