### PR TITLE
Fix missing road names at higher zooms

### DIFF
--- a/style.json
+++ b/style.json
@@ -4642,7 +4642,19 @@
         ],
         "text-field": "{name}",
         "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        "text-rotation-alignment": "map",
+        "text-allow-overlap": {
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              18,
+              true
+            ]
+          ]
+        }
       },
       "paint": {
         "text-halo-color": "#f8f4f0",
@@ -4693,7 +4705,19 @@
         ],
         "text-field": "{name}",
         "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        "text-rotation-alignment": "map",
+        "text-allow-overlap": {
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              18,
+              true
+            ]
+          ]
+        }
       },
       "paint": {
         "text-halo-blur": 0,
@@ -4738,7 +4762,19 @@
         ],
         "text-field": "{name}",
         "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        "text-rotation-alignment": "map",
+        "text-allow-overlap": {
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              18,
+              true
+            ]
+          ]
+        }
       },
       "paint": {
         "text-halo-blur": 0,


### PR DESCRIPTION
Proposes [what seems to be] a working fix for the rendering bug where street names disappear at very high zoom levels, making the map barely usable in some cases.

The fix is to allow overlapping of labels with over features after a threshold zoom, as apparently MapBoxGL rendering algorithm was considering labels in some area were always overlapping something at high zooms… Strangely, this doesn't happen everywhere, but in cities it's really common.
So, I'm not sure this fixes the original reason, but it seems to work visually. There are some strange placement issues though, like in the last screenshot here where the names are not centered on the road geometry.
Maybe it needs some more investigation.

|Production|With the fix|
|---|---|
|![maps dev qwant ninja_maps_](https://user-images.githubusercontent.com/243653/68226545-8af52180-fff2-11e9-8e5b-951f5c6207fe.png)|![localhost_3000_](https://user-images.githubusercontent.com/243653/68226565-92b4c600-fff2-11e9-9c04-9d0066ca3153.png)|
|![maps dev qwant ninja_maps_ (1)](https://user-images.githubusercontent.com/243653/68226603-9f391e80-fff2-11e9-8fc8-a1f4f751fe65.png)|![localhost_3000_ (1)](https://user-images.githubusercontent.com/243653/68226614-a2cca580-fff2-11e9-9a74-8dc081dc68a0.png)|


