### PR TITLE
Fix parking svg icons for webfont compatibility

### DIFF
--- a/icons/parking-11.svg
+++ b/icons/parking-11.svg
@@ -3,9 +3,7 @@
     <!-- Generator: Sketch 59.1 (86144) - https://sketch.com -->
     <title>parkingbike-11</title>
     <desc>Created with Sketch.</desc>
-    <g id="parkingbike-11" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-      <rect id="Rectangle" stroke="#123295" stroke-width="2" fill="#FFFFFF" fill-rule="nonzero" stroke-linejoin="round" x="1" y="1" width="21" height="21" rx="10.5"></rect>
-      <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="1" y="1" width="21" height="21" rx="10.5"></rect>
-      <path d="M14.5,12c-0.664,0.479,-1.473,0.712,-2.29,0.66h-1.91v3.24h-1.9v-9h3.93c0.7801,-0.0414,1.5484,0.2041,2.16,0.69c0.581,0.562,0.878,1.355,0.81,2.16c0.088,0.833,-0.206,1.66,-0.8,2.25zm-1.46,-3.24c-0.289,-0.2119,-0.6421,-0.3178,-1,-0.3h-1.74v2.65h1.72c0.3612,0.0191,0.717,-0.0947,1,-0.32c0.2559,-0.2675,0.3867,-0.6308,0.36,-1c0.052,-0.377,-0.073,-0.758,-0.34,-1.03z" fill="#123295"/>
-    </g>
+    <rect id="Rectangle" stroke="#123295" stroke-width="2" fill="#FFFFFF" fill-rule="nonzero" stroke-linejoin="round" x="1" y="1" width="21" height="21" rx="10.5"></rect>
+    <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="1" y="1" width="21" height="21" rx="10.5"></rect>
+    <path d="M14.5,12c-0.664,0.479,-1.473,0.712,-2.29,0.66h-1.91v3.24h-1.9v-9h3.93c0.7801,-0.0414,1.5484,0.2041,2.16,0.69c0.581,0.562,0.878,1.355,0.81,2.16c0.088,0.833,-0.206,1.66,-0.8,2.25zm-1.46,-3.24c-0.289,-0.2119,-0.6421,-0.3178,-1,-0.3h-1.74v2.65h1.72c0.3612,0.0191,0.717,-0.0947,1,-0.32c0.2559,-0.2675,0.3867,-0.6308,0.36,-1c0.052,-0.377,-0.073,-0.758,-0.34,-1.03z" fill="#123295"/>
 </svg>

--- a/icons/parking-15.svg
+++ b/icons/parking-15.svg
@@ -3,9 +3,7 @@
     <!-- Generator: Sketch 59.1 (86144) - https://sketch.com -->
     <title>parkingbike-15</title>
     <desc>Created with Sketch.</desc>
-    <g id="parkingbike-15" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect id="Rectangle" stroke="#123295" stroke-width="2" fill="#FFFFFF" fill-rule="nonzero" stroke-linejoin="round" x="1" y="1" width="25" height="25" rx="12.5"></rect>
-        <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="1" y="1" width="25" height="25" rx="12.5"></rect>
-        <path d="M18,14.5c-0.9532,0.7086,-2.1239,1.0623,-3.31,1h-2.75v4.63h-2.79v-13h5.72c1.1305,-0.0605,2.244,0.2952,3.13,1c0.8321,0.8147,1.2543,1.9601,1.15,3.12c0.127,1.201,-0.295,2.396,-1.15,3.25zm-2.1,-4.67c-0.425,-0.311,-0.945,-0.463,-1.47,-0.43h-2.49v3.82h2.49c0.5315,0.0326,1.056,-0.1351,1.47,-0.47c0.3795,-0.3947,0.5693,-0.9346,0.52,-1.48c0.054,-0.534,-0.137,-1.064,-0.52,-1.44z" fill="#123295"></path>
-    </g>
+    <rect id="Rectangle" stroke="#123295" stroke-width="2" fill="#FFFFFF" fill-rule="nonzero" stroke-linejoin="round" x="1" y="1" width="25" height="25" rx="12.5"></rect>
+    <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="1" y="1" width="25" height="25" rx="12.5"></rect>
+    <path d="M18,14.5c-0.9532,0.7086,-2.1239,1.0623,-3.31,1h-2.75v4.63h-2.79v-13h5.72c1.1305,-0.0605,2.244,0.2952,3.13,1c0.8321,0.8147,1.2543,1.9601,1.15,3.12c0.127,1.201,-0.295,2.396,-1.15,3.25zm-2.1,-4.67c-0.425,-0.311,-0.945,-0.463,-1.47,-0.43h-2.49v3.82h2.49c0.5315,0.0326,1.056,-0.1351,1.47,-0.47c0.3795,-0.3947,0.5693,-0.9346,0.52,-1.48c0.054,-0.534,-0.137,-1.064,-0.52,-1.44z" fill="#123295"></path>
 </svg>


### PR DESCRIPTION
On webfont build, the `<path>` element is to be found on the first level. 
No svg group should be used in these icons.