### PR TITLE
decrease density of POI's for lower layers

### DIFF
--- a/style.json
+++ b/style.json
@@ -4299,7 +4299,7 @@
         [
           ">=",
           "rank",
-          15
+          9
         ],
         [
           "!in",
@@ -4380,7 +4380,7 @@
         [
           "<=",
           "rank",
-          14
+          8
         ],
         [
           "!in",
@@ -4436,8 +4436,7 @@
         "text-anchor": "top",
         "text-field": "{name}",
         "text-optional": true,
-        "text-max-width": 9,
-        "icon-padding": 10
+        "text-max-width": 9
       },
       "paint": {
         "text-halo-blur": 0.5,


### PR DESCRIPTION
~**NOTE**: This change is only relevant after the application of https://github.com/QwantResearch/kartotherian_docker/pull/85.~
~**WARNING**: As this branch may lead to ugly results with the former tile generation, we shall use https://github.com/QwantResearch/qwant-basic-gl-style/pull/89 until tiles have been generated with the new prioritization.~

Limit the density of POI's by decreasing the maximal rank for a layer, instead of increasing the padding.

prod | #88
-- | --
![Screenshot_2019-12-17 Maputnik](https://user-images.githubusercontent.com/1173464/71010999-fb608980-20ec-11ea-932a-13def03e2a5e.png) | ![Screenshot_2019-12-17 Maputnik(1)](https://user-images.githubusercontent.com/1173464/71011018-00253d80-20ed-11ea-853a-efd4b8b54727.png)
