### PR TITLE
decrease density of POI's for lower layers

### DIFF
--- a/style.json
+++ b/style.json
@@ -4436,7 +4436,8 @@
         "text-anchor": "top",
         "text-field": "{name}",
         "text-optional": true,
-        "text-max-width": 9
+        "text-max-width": 9,
+        "icon-padding": 10
       },
       "paint": {
         "text-halo-blur": 0.5,


### PR DESCRIPTION
**NOTE**: This is a transitory PR to make the change smoother through the update of tiles. Final result we expect to merge is https://github.com/QwantResearch/qwant-basic-gl-style/pull/88.
**NOTE**: This change is only relevant after the application of QwantResearch/kartotherian_docker#85.

Importing Wikidata stats (cf. QwantResearch/kartotherian_docker#85) increased the count of relevant POI's, this resulted in an overcrowded POI layer for small zoom values.

Here is a comparison of the result of **this branch only** on both the production tiles and tiles generated with https://github.com/QwantResearch/kartotherian_docker/pull/85.

| production | [kartotherian_docker#85](https://github.com/QwantResearch/kartotherian_docker/pull/85) |
--|--
![Screenshot_2019-11-19 Maputnik(6)](https://user-images.githubusercontent.com/1173464/69162605-3b801c80-0aed-11ea-9b29-04891e5916f7.png)|![Screenshot_2019-11-19 Maputnik(4)](https://user-images.githubusercontent.com/1173464/69162611-3de27680-0aed-11ea-9d1f-72cc2f10f4fa.png)
![Screenshot_2019-11-19 Maputnik(7)](https://user-images.githubusercontent.com/1173464/69162616-3f13a380-0aed-11ea-86b5-f86eda76644b.png)|![Screenshot_2019-11-19 Maputnik(5)](https://user-images.githubusercontent.com/1173464/69162620-4044d080-0aed-11ea-95d3-903fa79cc673.png)

