### PR TITLE
Fix missing icon and text layout for capital cities

### DIFF
--- a/style.json
+++ b/style.json
@@ -5185,13 +5185,6 @@
         },
         "text-field": "{name}",
         "text-max-width": 8,
-        "icon-image": "star_11",
-        "text-offset": [
-          0.4,
-          0
-        ],
-        "icon-size": 0.8,
-        "text-anchor": "left",
         "visibility": "visible"
       },
       "paint": {


### PR DESCRIPTION
Fix the console warning message appearing on Qwant Maps when displaying a capital city name, about using a missing `star_11` file:
![Capture d’écran de 2019-11-22 14-35-16](https://user-images.githubusercontent.com/243653/69439680-c0ff0900-0d47-11ea-9400-1b68b4af2758.png)

This is a residue of the style we forked to create ours, which used a star for capitals:
![Capture d’écran de 2019-11-22 14-45-50](https://user-images.githubusercontent.com/243653/69439862-10453980-0d48-11ea-923f-1f135a4ead7a.png)

Also fix the position of the names, which were left aligned on the (missing) star icon position, so appeared off to the right. Now they are just centered like other city names.
**Let's see later if we want to differentiate capital cities with a better style.**

|Before|After|
|---|---|
|![Capture d’écran de 2019-11-22 16-42-00](https://user-images.githubusercontent.com/243653/69440083-7205a380-0d48-11ea-9220-bd456d3025be.png)|![Capture d’écran de 2019-11-22 16-45-50](https://user-images.githubusercontent.com/243653/69440093-75992a80-0d48-11ea-8148-cb95380d181f.png)|

