### PR TITLE
Style improvements about city and country labels

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -15,14 +15,16 @@ lang:
             - ''
         - - get
           - name:{locale}
-        - - concat
+        - - format
           - - get
             - name:{locale}
+          - {}
           - "\n"
-          - - concat
-            - - get
-              - name
-            - ''
+          - {}
+          - - get
+            - name
+          - 'font-scale': 0.8
+            'text-font': ['literal', ["Noto Sans Italic"]]
       - - case
         - - has
           - name:latin
@@ -38,12 +40,16 @@ lang:
               - ''
           - - get
             - name
-          - - concat
+          - - format
             - - get
               - name:latin
+            - {}
             - "\n"
+            - {}
             - - get
               - name
+            - 'font-scale': 0.8
+              'text-font': ['literal', ["Noto Sans Italic"]]
         - - get
           - name
     - &lang_locale

--- a/i18n.yml
+++ b/i18n.yml
@@ -150,19 +150,7 @@ languageFallbacks:
     lang:
       *lang_double
   -
-    id: place-country-other
-    lang:
-      *lang_locale
-  -
-    id: place-country-3
-    lang:
-      *lang_locale
-  -
-    id: place-country-2
-    lang:
-      *lang_locale
-  -
-    id: place-country-1
+    id: place-country
     lang:
       *lang_locale
   -

--- a/style.json
+++ b/style.json
@@ -5515,7 +5515,7 @@
       }
     },
     {
-      "id": "place-country-other",
+      "id": "place-country",
       "type": "symbol",
       "metadata": {
         "mapbox:group": "1444849242106.713",
@@ -5523,200 +5523,32 @@
       },
       "source": "basemap",
       "source-layer": "place",
+      "maxzoom": 12,
       "filter": [
         "all",
         [
           "==",
           "class",
           "country"
-        ],
-        [
-          ">=",
-          "rank",
-          3
-        ],
-        [
-          "!has",
-          "iso_a2"
         ]
       ],
       "layout": {
         "text-font": [
-          "Noto Sans Italic"
+          "case",
+          ["has", "iso_a2"],
+          ["literal", ["Noto Sans Bold"]],
+          ["literal", ["Noto Sans Italic"]]
         ],
         "text-field": "{name}",
         "text-size": {
+          "property": "rank",
           "stops": [
-            [
-              3,
-              11
-            ],
-            [
-              7,
-              17
-            ]
-          ]
-        },
-        "text-transform": "uppercase",
-        "text-max-width": 6.25,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-halo-blur": 1,
-        "text-color": "#334",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-country-3",
-      "type": "symbol",
-      "metadata": {
-        "mapbox:group": "1444849242106.713",
-        "taxonomy:group": "places"
-      },
-      "source": "basemap",
-      "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "country"
-        ],
-        [
-          ">=",
-          "rank",
-          3
-        ],
-        [
-          "has",
-          "iso_a2"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Bold"
-        ],
-        "text-field": "{name}",
-        "text-size": {
-          "stops": [
-            [
-              3,
-              11
-            ],
-            [
-              7,
-              17
-            ]
-          ]
-        },
-        "text-transform": "uppercase",
-        "text-max-width": 6.25,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-halo-blur": 1,
-        "text-color": "#334",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-country-2",
-      "type": "symbol",
-      "metadata": {
-        "mapbox:group": "1444849242106.713",
-        "taxonomy:group": "places"
-      },
-      "source": "basemap",
-      "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "country"
-        ],
-        [
-          "==",
-          "rank",
-          2
-        ],
-        [
-          "has",
-          "iso_a2"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Bold"
-        ],
-        "text-field": "{name}",
-        "text-size": {
-          "stops": [
-            [
-              2,
-              11
-            ],
-            [
-              5,
-              17
-            ]
-          ]
-        },
-        "text-transform": "uppercase",
-        "text-max-width": 6.25,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-halo-blur": 1,
-        "text-color": "#334",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-country-1",
-      "type": "symbol",
-      "metadata": {
-        "mapbox:group": "1444849242106.713",
-        "taxonomy:group": "places"
-      },
-      "source": "basemap",
-      "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "country"
-        ],
-        [
-          "==",
-          "rank",
-          1
-        ],
-        [
-          "has",
-          "iso_a2"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Bold"
-        ],
-        "text-field": "{name}",
-        "text-size": {
-          "stops": [
-            [
-              1,
-              11
-            ],
-            [
-              4,
-              17
-            ]
+            [{"zoom":1, "value": 1}, 11],
+            [{"zoom":1, "value": 3}, 11],
+            [{"zoom":3, "value": 1}, 15],
+            [{"zoom":3, "value": 3}, 11],
+            [{"zoom":7, "value": 1}, 17],
+            [{"zoom":7, "value": 3}, 17]
           ]
         },
         "text-transform": "uppercase",


### PR DESCRIPTION
* Use a smaller and italic font for local name in city labels (when used as a secondary label)
* Hide country labels for zoom >= 12
* Merge country labels into a single mapbox-gl style layer

### Before / After (gif)
![Peek 03-01-2020 14-09](https://user-images.githubusercontent.com/4726554/71725114-222ff700-2e33-11ea-9141-f8e7f90f6f9a.gif)
