### PR TITLE
Fix oneway road arrows colliding with POIs

### DIFF
--- a/style.json
+++ b/style.json
@@ -4824,41 +4824,18 @@
       }
     },
     {
-      "filter": ["all", ["==", "oneway", 1],
-        ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-      ],
       "id": "road_oneway",
-      "layout": {
-        "icon-image": "oneway",
-        "icon-padding": 2,
-        "icon-rotate": 90,
-        "icon-ignore-placement": true,
-        "icon-rotation-alignment": "map",
-        "icon-size": {
-          "stops": [
-            [15, 0.5],
-            [19, 1]
-          ]
-        },
-        "symbol-placement": "line",
-        "symbol-spacing": 75
-      },
-      "minzoom": 15,
-      "paint": {
-        "icon-opacity": 0.4
-      },
+      "type": "symbol",
       "source": "basemap",
       "source-layer": "transportation",
-      "type": "symbol"
-    }, {
-      "filter": ["all", ["==", "oneway", -1],
+      "minzoom": 15,
+      "filter": ["all", ["in", "oneway", 1, -1],
         ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
       ],
-      "id": "road_oneway_opposite",
       "layout": {
         "icon-image": "oneway",
         "icon-padding": 2,
-        "icon-rotate": -90,
+        "icon-rotate": ["case", ["==", ["get", "oneway"], 1], 90, -90],
         "icon-ignore-placement": true,
         "icon-rotation-alignment": "map",
         "icon-size": {
@@ -4870,13 +4847,9 @@
         "symbol-placement": "line",
         "symbol-spacing": 75
       },
-      "minzoom": 15,
       "paint": {
         "icon-opacity": 0.4
-      },
-      "source": "basemap",
-      "source-layer": "transportation",
-      "type": "symbol"
+      }
     },
     {
       "id": "highway-name-path",

--- a/style.json
+++ b/style.json
@@ -4380,6 +4380,34 @@
       }
     },
     {
+      "id": "road_oneway",
+      "type": "symbol",
+      "source": "basemap",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": ["all", ["in", "oneway", 1, -1],
+        ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
+      ],
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": ["case", ["==", ["get", "oneway"], 1], 90, -90],
+        "icon-ignore-placement": true,
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [15, 0.5],
+            [19, 1]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "paint": {
+        "icon-opacity": 0.4
+      }
+    },
+    {
       "id": "poi-level-no-name",
       "type": "symbol",
       "source": "poi",
@@ -4821,34 +4849,6 @@
         "text-color": "#000",
         "text-halo-width": 1,
         "text-halo-color": "#ffffff"
-      }
-    },
-    {
-      "id": "road_oneway",
-      "type": "symbol",
-      "source": "basemap",
-      "source-layer": "transportation",
-      "minzoom": 15,
-      "filter": ["all", ["in", "oneway", 1, -1],
-        ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-      ],
-      "layout": {
-        "icon-image": "oneway",
-        "icon-padding": 2,
-        "icon-rotate": ["case", ["==", ["get", "oneway"], 1], 90, -90],
-        "icon-ignore-placement": true,
-        "icon-rotation-alignment": "map",
-        "icon-size": {
-          "stops": [
-            [15, 0.5],
-            [19, 1]
-          ]
-        },
-        "symbol-placement": "line",
-        "symbol-spacing": 75
-      },
-      "paint": {
-        "icon-opacity": 0.4
       }
     },
     {


### PR DESCRIPTION
Change the order of style layers so that arrows indicating oneway road directions don't get drawn on top of important POI.

*Note: this new order doesn't change the fact that arrows are drawn on top of route results*

Also uses a single layer managing both directions, instead of two, which should improve slightly the style performance.

|Before|After|
|---|---|
|![Capture d’écran de 2020-03-13 16-22-51](https://user-images.githubusercontent.com/243653/76639593-aea31800-654e-11ea-964b-8defe3318bb9.png)|![Capture d’écran de 2020-03-13 16-58-34](https://user-images.githubusercontent.com/243653/76639628-bf538e00-654e-11ea-98b6-3356028ac97b.png)|
|![Capture d’écran de 2020-03-13 16-23-27](https://user-images.githubusercontent.com/243653/76639594-af3bae80-654e-11ea-88a8-a519773fc90a.png)|![Capture d’écran de 2020-03-13 16-59-08](https://user-images.githubusercontent.com/243653/76639638-c4b0d880-654e-11ea-8f34-3912d816754e.png)|
|![marais_bug](https://user-images.githubusercontent.com/243653/76639671-d5614e80-654e-11ea-8fd4-f1dbaa7174fe.png)|![marais_fixed](https://user-images.githubusercontent.com/243653/76639688-dbefc600-654e-11ea-853e-f893289ee631.png)|
|![bastille_bug](https://user-images.githubusercontent.com/243653/76639694-e27e3d80-654e-11ea-81d0-5f9732bcfc59.png)|![bastille_fixed](https://user-images.githubusercontent.com/243653/76639701-e742f180-654e-11ea-8793-888981e2c9ba.png)|


