### PR TITLE
Reduce number of layers (4 less)

### DIFF
--- a/style.json
+++ b/style.json
@@ -636,52 +636,7 @@
           "!=",
           "brunnel",
           "tunnel"
-        ],
-        ["!=", "intermittent", 1]
-      ],
-      "layout": {
-        "line-cap": "round"
-      },
-      "paint": {
-        "line-color": "#a0c8f0",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "waterway-stream-canal-intermittent",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849382550.77",
-        "taxonomy:group": "waterway"
-      },
-      "source": "basemap",
-      "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "canal",
-          "stream"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ],
-        ["==", "intermittent", 1]
+        ]
       ],
       "layout": {
         "line-cap": "round"

--- a/style.json
+++ b/style.json
@@ -795,30 +795,15 @@
       },
       "source": "basemap",
       "source-layer": "water",
-      "filter": ["all", ["!=", "intermittent", 1]],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "#BBE0FC"
-      }
-    },
-    {
-      "id": "water-intermittent",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849382550.77",
-        "taxonomy:group": "landuse"
-      },
-      "source": "basemap",
-      "source-layer": "water",
-      "filter": ["all", ["==", "intermittent", 1]],
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": "#BBE0FC",
-        "fill-opacity": 0.7
+        "fill-opacity": ["case",
+          ["==", ["get", "intermittent"], 1], 0.7,
+          1
+        ]
       }
     },
     {

--- a/style.json
+++ b/style.json
@@ -175,7 +175,7 @@
       }
     },
     {
-      "id": "landuse-commercial",
+      "id": "landuse-commercial-industrial",
       "type": "fill",
       "metadata": {
         "mapbox:group": "1444849388993.3071",
@@ -191,34 +191,9 @@
           "Polygon"
         ],
         [
-          "==",
+          "in",
           "class",
-          "commercial"
-        ]
-      ],
-      "paint": {
-        "fill-color": "hsla(49, 100%, 88%, 0.34)"
-      }
-    },
-    {
-      "id": "landuse-industrial",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071",
-        "taxonomy:group": "landuse"
-      },
-      "source": "basemap",
-      "source-layer": "landuse",
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "==",
-          "class",
+          "commercial",
           "industrial"
         ]
       ],

--- a/style.json
+++ b/style.json
@@ -343,24 +343,6 @@
       }
     },
     {
-      "id": "landcover-garden",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071",
-        "taxonomy:group": "landuse"
-      },
-      "source": "basemap",
-      "source-layer": "landcover",
-      "filter": [
-        "all",
-        ["==", "class", "grass"],
-        ["in", "subclass", "park", "garden"]
-      ],
-      "paint": {
-        "fill-color": "#c0eab8"
-      }
-    },
-    {
       "id": "landcover-grass",
       "type": "fill",
       "metadata": {
@@ -369,13 +351,12 @@
       },
       "source": "basemap",
       "source-layer": "landcover",
-      "filter": [
-        "all",
-        ["==", "class", "grass"],
-        ["!in", "subclass", "park", "garden"]
-      ],
+      "filter": ["==", "class", "grass"],
       "paint": {
-        "fill-color": "#e0f2d3"
+        "fill-color": ["case",
+          ["in", ["get", "subclass"], ["literal", ["park", "garden"]]], "#c0eab8",
+          "#e0f2d3"
+        ]
       }
     },
     {


### PR DESCRIPTION
### Description
This is a first batch of layer optimization, reducing the number of data layers in our style definition to follow Mapbox optimization guidelines.

I started with 4 layer merges for now, each one in a different commit, and I put the rationale behind each optim directly in the commit message, so it's definitely easier to **review commit by commit**.

Two layers can be merged when they meet these criteria:
- they are adjacent in the style def (so we don't mess up with drawing order)
- they apply to the same kind of features
- they define the same styling rules **or** define rules which can be written as "data-driven expressions", a syntax to apply different style values based on conditions expressed on data. Typically, they are written as switch/case expressions in the special Mapbox-GL style syntax. The only gotcha is, for some reason, shorthand syntax used for data filters doesn't seem to be supported in them.
So, instead of writing:
```json
"fill-color": ["case",
  ["in", "subclass", "park", "garden"], "#c0eab8",
  "#e0f2d3"
]
```
we have to write the full developped version:
```json
"fill-color": ["case",
  ["in", ["get", "subclass"], ["literal", ["park", "garden"]]], "#c0eab8",
  "#e0f2d3"
]
```

Beside that, they work quite well :)

**I could go on with more optims but I'll stop here for now so we can discuss if this process is ok and easy enough to follow. (for example, we could also decide to do a single PR for each.)**

### Comparison

||Before|After|
|---|---|---|
|Number of layers|118|114|

Computed easily with [jq](https://stedolan.github.io/jq/) using this command:
```
jq ' .layers | length ' style.json
```

### TODO

- [x] Update the @mapbox/mapbox-gl-style-spec dependency in https://github.com/QwantResearch/map-style-builder so the data-driven expressions are supported by the CI 
