### PR TITLE
Reduce number of layers. (Motorway bridges. 3 less)

### DIFF
--- a/style.json
+++ b/style.json
@@ -3459,60 +3459,6 @@
       }
     },
     {
-      "id": "bridge-motorway-link",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902",
-        "taxonomy:group": "bridges"
-      },
-      "source": "basemap",
-      "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "layout": {
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#fc8",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              18,
-              11.5
-            ],
-            [
-              20,
-              21.5
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id": "bridge-link",
       "type": "line",
       "metadata": {
@@ -3534,14 +3480,18 @@
           "primary_link",
           "secondary_link",
           "tertiary_link",
-          "trunk_link"
+          "trunk_link",
+          "motorway_link"
         ]
       ],
       "layout": {
         "line-join": "round"
       },
       "paint": {
-        "line-color": "#fea",
+        "line-color": ["case",
+          ["==", ["get", "class"], "motorway_link"], "#fc8",
+          "#fea"
+        ],
         "line-width": {
           "base": 1.2,
           "stops": [

--- a/style.json
+++ b/style.json
@@ -3085,62 +3085,6 @@
       }
     },
     {
-      "id": "bridge-motorway-link-casing",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902",
-        "taxonomy:group": "bridges",
-        "taxonomy:casing": "bridge-motorway-link"
-      },
-      "source": "basemap",
-      "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "layout": {
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              18,
-              15
-            ],
-            [
-              20,
-              25
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id": "bridge-link-casing",
       "type": "line",
       "metadata": {
@@ -3163,7 +3107,8 @@
           "primary_link",
           "secondary_link",
           "tertiary_link",
-          "trunk_link"
+          "trunk_link",
+          "motorway_link"
         ]
       ],
       "layout": {

--- a/style.json
+++ b/style.json
@@ -3535,56 +3535,7 @@
           "in",
           "class",
           "primary",
-          "trunk"
-        ]
-      ],
-      "layout": {
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              18,
-              18
-            ],
-            [
-              20,
-              38
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "bridge-motorway",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902",
-        "taxonomy:group": "bridges"
-      },
-      "source": "basemap",
-      "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
+          "trunk",
           "motorway"
         ]
       ],
@@ -3592,7 +3543,10 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "#fc8",
+        "line-color": ["case",
+          ["==", ["get", "class"], "motorway"], "#fc8",
+          "#fea"
+        ],
         "line-width": {
           "base": 1.2,
           "stops": [


### PR DESCRIPTION
Follow-up to https://github.com/QwantResearch/qwant-basic-gl-style/pull/99

Remove 3 more layers, each on the same principle: a special style was applied to motorway briges compared to other road briges, but this special case can be achieved which a data-driven style expression testing if the feature class is motorway, instead of defining a separate layer.

||Before|After|
|---|---|---|
|Number of layers|114|111|