### PR TITLE
Put recycling in interactive POI layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -4081,7 +4081,6 @@
             "pitch",
             "post_box",
             "post_office",
-            "recycling",
             "sally_port",
             "shelter",
             "stile",
@@ -4247,42 +4246,53 @@
         ],
         [
           "!in",
-          "subclass",
-          "artwork",
-          "bollard",
-          "bicycle_rental",
-          "border_control",
-          "cycle_barrier",
-          "ferry_terminal",
-          "gate",
-          "lift_gate",
-          "playground",
-          "pitch",
-          "post_box",
-          "post_office",
-          "recycling",
-          "sally_port",
-          "shelter",
-          "stile",
-          "taxi",
-          "telephone",
-          "toll_booth",
-          "toilets",
-          "subway_entrance",
-          "train_station_entrance",
-          "waste_basket"
-        ],
-        [
-          "has",
-          "name"
-        ],
-        [
-          "!in",
           "class",
           "railway",
           "bus",
           "information",
           "barrier"
+        ],
+        [
+          "any",
+          [
+            "all",
+            [
+              "!in",
+              "subclass",
+              "artwork",
+              "bollard",
+              "bicycle_rental",
+              "border_control",
+              "cycle_barrier",
+              "ferry_terminal",
+              "gate",
+              "lift_gate",
+              "playground",
+              "pitch",
+              "post_box",
+              "post_office",
+              "recycling",
+              "sally_port",
+              "shelter",
+              "stile",
+              "taxi",
+              "telephone",
+              "toll_booth",
+              "toilets",
+              "subway_entrance",
+              "train_station_entrance",
+              "waste_basket"
+            ],
+            [
+              "has",
+              "name"
+            ]
+          ],
+          [
+            "in",
+            "subclass",
+            "recycling"
+          ]
         ]
       ],
       "layout": {


### PR DESCRIPTION
Change the layer of `subclass=recycling` POIs, from `poi-level-street-furniture` to `poi-level-3`.
This will make them clickable on Qwant Maps as Erdapfel adds interactivy to this layer.
Had to complexify the `poi-level-3` a bit to include an exception for these POI, as we don't require them to have a name, contrary to others POIs in this layer.