### PR TITLE
Optim: Simplify filter expressions

### DIFF
--- a/style.json
+++ b/style.json
@@ -157,7 +157,7 @@
       },
       "source": "basemap",
       "source-layer": "landuse",
-      "filter": ["all", ["in", "class", "residential", "suburb", "neighbourhood"]],
+      "filter": ["in", "class", "residential", "suburb", "neighbourhood"],
       "paint": {
         "fill-color": {
           "base": 1,
@@ -829,14 +829,7 @@
       },
       "source": "basemap",
       "source-layer": "landcover",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "sand"
-        ]
-      ],
+      "filter": ["==", "class", "sand"],
       "layout": {
         "visibility": "visible"
       },
@@ -1537,14 +1530,7 @@
       },
       "source": "basemap",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "ferry"
-        ]
-      ],
+      "filter": ["in", "class", "ferry"],
       "layout": {
         "line-join": "round",
         "visibility": "visible"
@@ -4932,13 +4918,7 @@
       "source": "basemap",
       "source-layer": "aerodrome_label",
       "minzoom": 10,
-      "filter": [
-        "all",
-        [
-          "has",
-          "iata"
-        ]
-      ],
+      "filter": ["has", "iata"],
       "layout": {
         "text-padding": 2,
         "text-font": [
@@ -5252,14 +5232,7 @@
       "source": "basemap",
       "source-layer": "place",
       "maxzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "country"
-        ]
-      ],
+      "filter": ["==", "class", "country"],
       "layout": {
         "text-font": [
           "case",

--- a/style.json
+++ b/style.json
@@ -1186,17 +1186,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "path"
         ]
       ],
       "paint": {
@@ -1943,19 +1940,16 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!=",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "minor",
-            "service",
-            "track"
-          ]
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
         ]
       ],
       "layout": {
@@ -2289,18 +2283,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "path"
         ]
       ],
       "paint": {
@@ -2463,19 +2454,16 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!=",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "minor",
-            "service",
-            "track"
-          ]
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
         ]
       ],
       "layout": {
@@ -2579,18 +2567,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "primary"
-          ]
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary"
         ]
       ],
       "layout": {
@@ -2640,18 +2625,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "trunk"
-          ]
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk"
         ]
       ],
       "layout": {
@@ -2702,18 +2684,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
         ]
       ],
       "layout": {
@@ -2763,17 +2742,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "class",
-            "transit"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "tunnel"
-          ]
+          "==",
+          "class",
+          "transit"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
         ]
       ],
       "layout": {
@@ -2812,17 +2788,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "class",
-            "transit"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "tunnel"
-          ]
+          "==",
+          "class",
+          "transit"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
         ]
       ],
       "layout": {
@@ -2870,16 +2843,13 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "class",
-            "rail"
-          ],
-          [
-            "has",
-            "service"
-          ]
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "has",
+          "service"
         ]
       ],
       "paint": {
@@ -2915,16 +2885,13 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "class",
-            "rail"
-          ],
-          [
-            "has",
-            "service"
-          ]
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "has",
+          "service"
         ]
       ],
       "layout": {
@@ -2972,22 +2939,19 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!has",
-            "service"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "rail"
-          ]
+          "!has",
+          "service"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
         ]
       ],
       "paint": {
@@ -3027,22 +2991,19 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!has",
-            "service"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "rail"
-          ]
+          "!has",
+          "service"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
         ]
       ],
       "paint": {
@@ -3308,17 +3269,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "path"
         ]
       ],
       "paint": {
@@ -3355,17 +3313,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "path"
         ]
       ],
       "paint": {
@@ -4747,19 +4702,16 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "network",
-            "us-highway",
-            "us-interstate",
-            "us-state"
-          ],
-          [
-            "<=",
-            "ref_length",
-            6
-          ]
+          "!in",
+          "network",
+          "us-highway",
+          "us-interstate",
+          "us-state"
+        ],
+        [
+          "<=",
+          "ref_length",
+          6
         ]
       ],
       "layout": {
@@ -4806,17 +4758,14 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "<=",
-            "ref_length",
-            6
-          ],
-          [
-            "==",
-            "network",
-            "us-interstate"
-          ]
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "network",
+          "us-interstate"
         ]
       ],
       "layout": {
@@ -4869,18 +4818,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "<=",
-            "ref_length",
-            6
-          ],
-          [
-            "in",
-            "network",
-            "us-highway",
-            "us-state"
-          ]
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "in",
+          "network",
+          "us-highway",
+          "us-state"
         ]
       ],
       "layout": {


### PR DESCRIPTION
Rewrite some filter expressions in a simpler way, for easier reading/maintenance and maybe even a small perf bump.

Two rules were applied here:

### 1. Remove unecessary `all` operators
Some `all` were applied on one-rule filters.
```json
"filter": [
  "all",
   ["==", "A", "foo"]
]
```
This can be simplified to:
```json
"filter": ["==", "A", "foo"]
```

### 2. Flatten nested `all` operators
A lot of rules were written with this form:
```json
"filter": [
  "all",
   ["==", "A", "foo"],
   ["all", 
      ["==", "B", "bar"],
      ["==", "C", "baz"]
   ]
]
```
This can be simplified to:
```json
"filter": [
  "all",
   ["==", "A", "foo"],
   ["==", "B", "bar"],
   ["==", "C", "baz"]
]
```
