### PR TITLE
QMAPS-1073 change default administrative icon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 node_js:
-  - '8'
+  - '10'
 addons:
   apt:
     sources:

--- a/icons.yml
+++ b/icons.yml
@@ -1,6 +1,6 @@
 defaultIcon: marker2-11
 defaultColor: &default_color '#5C6F84'
-defaultAdministrativeIcon: town-11
+defaultAdministrativeIcon: marker2-11
 defaultAdministrativeColor: *default_color
 defaultStreetIcon: residential-community-11
 defaultStreetColor: *default_color


### PR DESCRIPTION
Use "marker2" instead of "town" for "defaultAdministrativeIcon"