### PR TITLE
Use library icon for 'public_bookcase'

### DIFF
--- a/icons.yml
+++ b/icons.yml
@@ -389,6 +389,9 @@ mappings:
   - class: library
     iconName: library-11
     color: *services_color
+  - subclass: public_bookcase
+    iconName: library-11
+    color: *services_color
   - class: laundry
     iconName: laundry-11
     color: *services_color


### PR DESCRIPTION
An icon for [`amenity=public_bookcase`](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dpublic_bookcase)