### PR TITLE
Expose icon mapping code as a JS module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+import iconStyles from './icons.yml';
+
+const nameToClass = iconName => iconName.match(/^(.*?)-[0-9]{1,2}$/)[1];
+
+function getIconFromMapping({ className, subClassName }) {
+  const icons = iconStyles.mappings;
+  const icon =
+    // Matching class and subclass
+    icons.find(iconProperty =>
+      iconProperty.subclass === subClassName && iconProperty.class === className)
+  ||
+    // Or: no class and matching subclass
+    icons.find(iconProperty => 
+      iconProperty.subclass === subClassName && !iconProperty.class)
+  ||
+    // Or: matching class and no subclass
+    icons.find(iconProperty => 
+      iconProperty.class === className && !iconProperty.subclass);
+
+  return icon;
+}
+
+function getPoiIcon({ className, subClassName, type }) {
+  let iconName, color;
+
+  // Get the icon of a location / area that is not a PoI:
+  switch (type) {
+    case 'poi':
+    case 'category':
+      const icon = getIconFromMapping({ className, subClassName });
+      iconName = icon ? icon.iconName : iconStyles.defaultIcon;
+      color = icon ? icon.color : iconStyles.defaultColor;
+      break;
+    
+    // Exact address
+    case 'house':
+    case 'address':
+      iconName = iconStyles.defaultAddressIcon;
+      color = iconStyles.defaultAddressColor;
+      break;
+
+    // Road / street without house number
+    case 'street':
+      iconName = iconStyles.defaultStreetIcon;
+      color = iconStyles.defaultStreetColor;
+      break;
+
+    // Administrative zones (city, area, country)
+    default:
+      iconName = iconStyles.defaultAdministrativeIcon;
+      color = iconStyles.defaultAdministrativeColor;
+  }
+
+  return {
+    iconClass: nameToClass(iconName),
+    color,
+  }
+}
+
+export { getPoiIcon };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@qwant/qwant-basic-gl-style",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@qwant/qwant-basic-gl-style",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "a map GL Style for Qwant Map",
   "main": "index.js",
   "keywords": [
     "gl-style"
   ],
   "author": "Qwant Research",
-  "license": "BSD-3"
+  "license": "BSD-3",
+  "type": "module"
 }


### PR DESCRIPTION
Add a JS file to the project to expose a function `getPoiIcon` returning the icon class and associated color of POI by types, as defined in the mapping in `icons.yml`.

This code is [currently in Erdapfel](https://github.com/QwantResearch/erdapfel/blob/master/src/adapters/icon_manager.js), but putting it in this lib will allow to share the POI type icon system more easily with other projects.

## Note about bundling, transpiling, etc.
For now I just exposed this file as a native ES6 module, with no defined bundling, transpiling or transforming of the YAML dependency. 
This is on purpose, as as first step, because Erdapfel can import and use this natively. The very next step will be to use this module from Erdapfel and delete the code that was migrated here
=> [That Erdapfel PR](https://github.com/QwantResearch/erdapfel/pull/1016) does that and can be used to test this current PR.

To plan for uses outside of Erdapfel, we'll probably have to add some bundling workflow. I'm thinking about [Rollup](https://rollupjs.org/), which is a simpler choice than Webpack for libs. But let's discuss that separately.