### PR TITLE
Improve town/city visual hierarchy

### DIFF
--- a/icons/place-circled-dot-black.svg
+++ b/icons/place-circled-dot-black.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20.003">
+  <g stroke="#000" stroke-linecap="round" transform="matrix(.88458 0 0 .88458 -82.881 -121.359)">
+    <circle cx="105" cy="148.5" r="9.611" fill="#fff" stroke-width="2"/>
+    <circle cx="105" cy="148.5" r="6.128" stroke-width="1.275"/>
+  </g>
+</svg>

--- a/icons/place-dot-black.svg
+++ b/icons/place-dot-black.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+  <circle cx="86.179" cy="139.095" r="9.058" stroke="#000" stroke-width="1.885" stroke-linecap="round" />
+</svg>

--- a/style.json
+++ b/style.json
@@ -4977,13 +4977,14 @@
           ]
         },
         "text-font": [
-          "Noto Sans Bold"
+          "Noto Sans Regular"
         ],
         "text-field": "{name}",
         "text-max-width": 9
       },
       "paint": {
-        "text-color": "hsl(0, 0%, 24%)",
+        "text-color": "#0c0c0e",
+        "text-opacity": 0.8,
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
       }
@@ -4997,6 +4998,7 @@
       },
       "source": "basemap",
       "source-layer": "place",
+      "maxzoom": 17,
       "filter": [
         "==",
         "class",
@@ -5011,21 +5013,22 @@
           "stops": [
             [
               10,
-              12
+              11
             ],
             [
               15,
-              22
+              20
             ]
           ]
         },
+        "text-anchor": "center",
         "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"
       },
       "paint": {
-        "text-color": "#333",
-        "text-halo-width": 1.2,
+        "text-color": "#0c0c0e",
+        "text-halo-width": 1.5,
         "text-halo-color": "rgba(255,255,255,0.8)"
       }
     },
@@ -5038,6 +5041,7 @@
       },
       "source": "basemap",
       "source-layer": "place",
+      "maxzoom": 17,
       "filter": [
         "==",
         "class",
@@ -5062,12 +5066,28 @@
         },
         "text-field": "{name}",
         "text-max-width": 8,
+        "text-offset": [
+          "step",
+          ["zoom"],
+          ["literal", [0, -0.3]],
+          8,
+          ["literal", [0, 0]]
+        ],
+        "text-anchor": {
+          "stops": [
+            [0, "bottom"],
+            [8, "center"]
+          ]
+        },
+        "icon-image": "place-dot-black",
+        "icon-size": 0.25,
         "visibility": "visible"
       },
       "paint": {
-        "text-color": "#333",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-color": "#0c0c0e",
+        "text-halo-width": 1.5,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "icon-opacity": ["step", ["zoom"], 1, 8, 0]
       }
     },
     {
@@ -5079,6 +5099,7 @@
       },
       "source": "basemap",
       "source-layer": "place",
+      "maxzoom": 16,
       "filter": [
         "all",
         [
@@ -5098,25 +5119,32 @@
         ],
         "text-size": {
           "base": 1.2,
-          "stops": [
-            [
-              7,
-              14
-            ],
-            [
-              11,
-              24
-            ]
-          ]
+          "stops": [[7, 13], [10, 18], [15, 26]]
         },
         "text-field": "{name}",
         "text-max-width": 8,
+        "text-offset": [
+          "step",
+          ["zoom"],
+          ["literal", [0, -0.3]],
+          8,
+          ["literal", [0, 0]]
+        ],
+        "text-anchor": {
+          "stops": [
+            [0, "bottom"],
+            [8, "center"]
+          ]
+        },
+        "icon-image": "place-dot-black",
+        "icon-size": 0.33,
         "visibility": "visible"
       },
       "paint": {
-        "text-color": "#333",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-color": "#0c0c0e",
+        "text-halo-width": 2,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "icon-opacity": ["step", ["zoom"], 1, 8, 0]
       }
     },
     {
@@ -5128,6 +5156,7 @@
       },
       "source": "basemap",
       "source-layer": "place",
+      "maxzoom": 15,
       "filter": [
         "all",
         [
@@ -5142,30 +5171,40 @@
         ]
       ],
       "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
+        "text-font": {
+          "stops": [
+            [0, ["Noto Sans Bold"]],
+            [8, ["Noto Sans Regular"]]
+          ]
+        },
         "text-size": {
           "base": 1.2,
-          "stops": [
-            [
-              7,
-              14
-            ],
-            [
-              11,
-              24
-            ]
-          ]
+          "stops": [[7, 15], [10, 24], [15, 32]]
         },
         "text-field": "{name}",
         "text-max-width": 8,
+        "text-offset": [
+          "step",
+          ["zoom"],
+          ["literal", [0, -0.3]],
+          8,
+          ["literal", [0, 0]]
+        ],
+        "text-anchor": {
+          "stops": [
+            [0, "bottom"],
+            [8, "center"]
+          ]
+        },
+        "icon-image": "place-circled-dot-black",
+        "icon-size": 0.5,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "#333",
         "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "icon-opacity": ["step", ["zoom"], 1, 8, 0]
       }
     },
     {


### PR DESCRIPTION
From https://github.com/Qwant/qwant-basic-gl-style/pull/116, extract and tweak enhancements about the place typography and iconography:
 - for zoom < 8, display the places with a small icons to enrich the map and be more precise about the actual position
 - better distinction between the 4 place levels (village, town, city, capital), through font size and weight
 - slightly darker text color for clarity
 - hide the place names when reaching street level zooms

![Capture d’écran de 2021-09-09 14-04-09](https://user-images.githubusercontent.com/243653/132682801-6d4611df-28e2-4f8b-aa46-a912fc8f68f6.png)

![Capture d’écran de 2021-09-09 14-06-20](https://user-images.githubusercontent.com/243653/132682806-b9c0dc9d-8548-4c5a-8d2a-16b782da845f.png)

![Capture d’écran de 2021-09-09 14-00-44](https://user-images.githubusercontent.com/243653/132682068-0ec02354-f10d-4160-ba0c-8bdc354edda0.png)
